### PR TITLE
Slot API - Resolve

### DIFF
--- a/lib/aws/lex/conversation/type/slot.rb
+++ b/lib/aws/lex/conversation/type/slot.rb
@@ -7,6 +7,7 @@ module Aws
         class Slot
           include Base
 
+          required :current_intent, from: :current_intent, virtual: true
           required :name
           required :value
 
@@ -16,6 +17,28 @@ module Aws
 
           def filled?
             value.to_s != ''
+          end
+
+          def resolve!(index: 0)
+            self.value = resolved(index: index)
+          end
+
+          def resolved(index: 0)
+            details.resolutions.fetch(index) { SlotResolution.new(value: value) }.value
+          end
+
+          def original_value
+            details.original_value
+          end
+
+          def resolvable?
+            details.resolutions.any?
+          end
+
+          def details
+            @details ||= current_intent.slot_details.fetch(name.to_sym) do
+              SlotDetail.new(name: name, resolutions: [], original_value: value)
+            end
           end
         end
       end

--- a/lib/aws/lex/conversation/version.rb
+++ b/lib/aws/lex/conversation/version.rb
@@ -3,7 +3,7 @@
 module Aws
   module Lex
     class Conversation
-      VERSION = '1.0.0'
+      VERSION = '1.1.0'
     end
   end
 end

--- a/spec/aws/lex/conversation/type/slot_spec.rb
+++ b/spec/aws/lex/conversation/type/slot_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 describe Aws::Lex::Conversation::Type::Slot do
-  subject { described_class.new(value: value) }
+  let(:current_intent) { build(:current_intent) }
+  let(:name) { :test }
+  subject { described_class.new(value: value, name: name, current_intent: current_intent) }
 
   describe '#filled?' do
     context 'it has a nil value' do
@@ -25,6 +27,91 @@ describe Aws::Lex::Conversation::Type::Slot do
 
       it 'returns true' do
         expect(subject.filled?).to eq(true)
+      end
+    end
+  end
+
+  describe '#resolve!' do
+    let(:name) { :resolvable }
+    let(:value) { 'one two' }
+
+    it 'overwrites the slot\'s value with the resolved value' do
+      expect(subject.value).to eq(value)
+      subject.resolve!
+      expect(subject.value).to eq('12')
+    end
+  end
+
+  describe '#resolved' do
+    let(:name) { :resolvable }
+    let(:value) { 'one two' }
+
+    context 'with an index that exists' do
+      it 'returns the resolved value' do
+        expect(subject.resolved(index: 0)).to eq('12')
+      end
+    end
+
+    context 'with an index that does not exist' do
+      it 'returns the current value' do
+        expect(subject.resolved(index: 1)).to eq(subject.value)
+      end
+    end
+  end
+
+  describe '#original_value' do
+    let(:name) { :resolvable }
+    let(:value) { 'one two' }
+
+    it 'returns the original value as interpreted by Lex' do
+      expect(subject.original_value).to eq('one. two.')
+    end
+  end
+
+  describe '#resolvable?' do
+    context 'when resolutions exist' do
+      let(:name) { :resolvable }
+      let(:value) { 'one two' }
+
+      it 'returns true' do
+        expect(subject.resolvable?).to be(true)
+      end
+    end
+
+    context 'when resolutions do not exist' do
+      let(:name) { :unresolvable }
+      let(:value) { 'one two' }
+
+      it 'returns false' do
+        expect(subject.resolvable?).to be(false)
+      end
+    end
+  end
+
+  describe '#details' do
+    context 'when a matching key in slot_details exists' do
+      let(:name) { :resolvable }
+      let(:value) { current_intent.slot_details[name].original_value }
+
+      it 'returns a SlotDetail instance' do
+        expect(subject.details).to be_a(Aws::Lex::Conversation::Type::SlotDetail)
+      end
+
+      it 'contains the correct resolution data' do
+        expect(subject.details.resolutions.size).to eq(1)
+      end
+    end
+
+    context 'when a matching key in slot_details does not exist' do
+      let(:name) { :empty }
+      let(:value) { nil }
+
+      it 'returns a new null SlotDetail instance' do
+        expect(subject.details).to be_a(Aws::Lex::Conversation::Type::SlotDetail)
+      end
+
+      it 'contains no resolution data' do
+        expect(subject.details.resolutions).to be_empty
       end
     end
   end

--- a/spec/factories/types/current_intents.rb
+++ b/spec/factories/types/current_intents.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory(
+    :current_intent,
+    class: Aws::Lex::Conversation::Type::CurrentIntent
+  ) do
+    name { 'TestIntent' }
+    raw_slots { { resolvable: 'one two', unresolvable: 'value', empty: nil } }
+    slot_details do
+      {
+        resolvable: Aws::Lex::Conversation::Type::SlotDetail.new(
+          original_value: 'one. two.',
+          resolutions: [
+            Aws::Lex::Conversation::Type::SlotResolution.new(value: '12')
+          ]
+        ),
+        unresolvable: Aws::Lex::Conversation::Type::SlotDetail.new(
+          original_value: 'value',
+          resolutions: []
+        )
+      }
+    end
+    confirmation_status { Aws::Lex::Conversation::Type::ConfirmationStatus.new('None') }
+
+    initialize_with do
+      new(
+        name: name,
+        raw_slots: raw_slots,
+        slot_details: slot_details,
+        confirmation_status: confirmation_status
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Example

```ruby
conversation = Aws::Lex::Conversation.new(event: event, context: context)
conversation.lex.current_intent.slot_details[:name] # => <SlotDetail resolutions=["123"], original_value="one two three">
conversation.slots[:name].value # => "one two three"
conversation.slots[:name].resolvable? # => true
conversation.slots[:name].resolved # => "123"
conversation.slots[:name].resolve! # set the slot value to be the resolved value
conversation.slots[:name].value # =>"123" 
```

## Overview
* Lex offers slot "resolutions" that contain a mapping of
  values that the Lex model thinks are the closest match
  to the actual slot value.
* Add the `resolvable?`, `resolved` and `resolve!`  methods
  to `Aws::Lex::Conversation::Type::Slot` to help work
  with these resolved values.
* Implement the notion of `virtual` attributes in the
  type classes. Virtual attributes are stored as instance
  variables on the type instances, but do not resolve in
  the lex response.
* Add a `computed_property` class method so that we can
  compute properties based on instance property values. These
  computed properties are memoized to reduce the number of
  method calls necessary.
* Pass down the `current_intent` parent instance to the
  individual slot instances so that the children are able
  to correctly resolve slot values based on the `slot_details`
  on the current intent.
* Add tests for all new behaviour.
* Bump version to 1.1.0 - this is  a non-breaking change.