### PR TITLE
Slot API - Fix

### DIFF
--- a/lib/aws/lex/conversation/type/slot.rb
+++ b/lib/aws/lex/conversation/type/slot.rb
@@ -11,6 +11,10 @@ module Aws
           required :name
           required :value
 
+          def as_json(_opts = {})
+            to_lex
+          end
+
           def to_lex
             value
           end

--- a/lib/aws/lex/conversation/version.rb
+++ b/lib/aws/lex/conversation/version.rb
@@ -3,7 +3,7 @@
 module Aws
   module Lex
     class Conversation
-      VERSION = '1.1.0'
+      VERSION = '1.1.1'
     end
   end
 end

--- a/spec/aws/lex/conversation/type/slot_spec.rb
+++ b/spec/aws/lex/conversation/type/slot_spec.rb
@@ -31,6 +31,15 @@ describe Aws::Lex::Conversation::Type::Slot do
     end
   end
 
+  describe '#as_json' do
+    let(:name) { :resolvable }
+    let(:value) { 'test' }
+
+    it 'returns the slot value' do
+      expect(subject.as_json).to eq(value)
+    end
+  end
+
   describe '#resolve!' do
     let(:name) { :resolvable }
     let(:value) { 'one two' }


### PR DESCRIPTION
* When introducing the gem with activesupport/active-model-serializers,
  a StackOverflow exception is raised when calling
 `conversation.slots.to_json`.
* This occurs because the Slot instance now contains a backreference
  and activesupport/AMS is unable to detect the loop.
* A simple reoslution is to define our own `as_json` method.
* Bump version to 1.1.1.