### PR TITLE
fix(slot-detail) - Nil Check on Slot Details

### DIFF
--- a/lib/aws/lex/conversation/type/current_intent.rb
+++ b/lib/aws/lex/conversation/type/current_intent.rb
@@ -26,10 +26,12 @@ module Aws
 
           class << self
             def slot_details!
-              ->(v) do
-                v.each_with_object({}) do |(key, value), hash|
-                  hash[key.to_sym] = SlotDetail.shrink_wrap(value)
-                end
+              ->(val) do
+                val
+                  .reject { |_, v| v.nil? }
+                  .each_with_object({}) do |(key, value), hash|
+                    hash[key.to_sym] = SlotDetail.shrink_wrap(value)
+                  end
               end
             end
           end

--- a/lib/aws/lex/conversation/version.rb
+++ b/lib/aws/lex/conversation/version.rb
@@ -3,7 +3,7 @@
 module Aws
   module Lex
     class Conversation
-      VERSION = '1.1.1'
+      VERSION = '1.1.2'
     end
   end
 end


### PR DESCRIPTION
* In Lex events, it's possible for the SlotDetail keys to have
  a null/nil value. Previously we would try to create a new
  instance of `SlotDetail` while passing `nil` to the constructor.
* Instead we can simply reject all nil values from the SlotDetails
  hash, then everything should work without issue.
* Bump version to 1.1.2.