### PR TITLE
feat(defaults): Default Session and Request Attributes

### DIFF
--- a/lib/aws/lex/conversation.rb
+++ b/lib/aws/lex/conversation.rb
@@ -88,7 +88,7 @@ module Aws
       # rubocop:enable Metrics/AbcSize
 
       def checkpoint?(label:)
-        lex.recent_intent_summary_view.any? { |v| v.checkpoint_label == label }
+        !checkpoint(label: label).nil?
       end
 
       def checkpoint(label:)

--- a/lib/aws/lex/conversation/type/event.rb
+++ b/lib/aws/lex/conversation/type/event.rb
@@ -16,9 +16,9 @@ module Aws
           required :invocation_source
           required :output_dialog_mode
           required :message_version
-          required :session_attributes
+          required :session_attributes, default: -> { {} }
           required :recent_intent_summary_view, default: -> { [] }
-          optional :request_attributes
+          required :request_attributes, default: -> { {} }
           optional :sentiment_response
           optional :kendra_response
 

--- a/lib/aws/lex/conversation/version.rb
+++ b/lib/aws/lex/conversation/version.rb
@@ -3,7 +3,7 @@
 module Aws
   module Lex
     class Conversation
-      VERSION = '3.0.0'
+      VERSION = '3.1.0'
     end
   end
 end

--- a/spec/aws/lex/conversation/type/event_spec.rb
+++ b/spec/aws/lex/conversation/type/event_spec.rb
@@ -19,4 +19,26 @@ describe Aws::Lex::Conversation::Type::Event do
       ])
     end
   end
+
+  describe '#session_attributes' do
+    context 'when the value is null' do
+      let(:event) { parse_fixture('events/intents/null_session.json') }
+
+      it 'returns an empty hash' do
+        expect(subject.session_attributes).to be_a(Hash)
+        expect(subject.session_attributes).to be_empty
+      end
+    end
+  end
+
+  describe '#request_attributes' do
+    context 'when the value is null' do
+      let(:event) { parse_fixture('events/intents/null_session.json') }
+
+      it 'returns an empty hash' do
+        expect(subject.request_attributes).to be_a(Hash)
+        expect(subject.request_attributes).to be_empty
+      end
+    end
+  end
 end

--- a/spec/fixtures/events/intents/null_session.json
+++ b/spec/fixtures/events/intents/null_session.json
@@ -1,0 +1,99 @@
+{
+  "messageVersion": "1.0",
+  "invocationSource": "DialogCodeHook",
+  "userId": "8df8adca-faad-4ec9-83af-50bce5882e3f",
+  "sessionAttributes": null,
+  "requestAttributes": null,
+  "bot": {
+    "name": "Lex_Bot_Test",
+    "alias": "PROD",
+    "version": "12"
+  },
+  "outputDialogMode": "Text",
+  "currentIntent": {
+    "name": "Lex_Intent_1",
+    "slots": {
+      "one": null,
+      "two": null,
+      "three": null,
+      "four": null,
+      "five": null
+    },
+    "slotDetails": {
+      "one": null,
+      "two": null,
+      "three": null,
+      "four": null,
+      "five": null
+    },
+    "confirmationStatus": "None",
+    "nluIntentConfidenceScore": 0.88
+  },
+  "alternativeIntents": [
+    {
+      "name": "Lex_Intent_2",
+      "slots": {},
+      "slotDetails": {},
+      "confirmationStatus": "None",
+      "nluIntentConfidenceScore": 0.73
+    },
+    {
+      "name": "Lex_Intent_3",
+      "slots": {
+        "one": null,
+        "two": null,
+        "three": null,
+        "four": null,
+        "five": null
+      },
+      "slotDetails": {
+        "one": null,
+        "two": null,
+        "three": null,
+        "four": null,
+        "five": null
+      },
+      "confirmationStatus": "None",
+      "nluIntentConfidenceScore": 0.5
+    },
+    {
+      "name": "AMAZON.FallbackIntent",
+      "slots": {},
+      "slotDetails": {},
+      "confirmationStatus": "None",
+      "nluIntentConfidenceScore": null
+    },
+    {
+      "name": "Lex_Intent_4",
+      "slots": {
+        "one": null,
+        "two": null,
+        "three": null,
+        "four": null,
+        "five": null,
+        "six": null,
+        "seven": null,
+        "eight": null
+      },
+      "slotDetails": {
+        "one": null,
+        "two": null,
+        "three": null,
+        "four": null,
+        "five": null,
+        "six": null,
+        "seven": null,
+        "eight": null
+      },
+      "confirmationStatus": "None",
+      "nluIntentConfidenceScore": 0.4
+    }
+  ],
+  "inputTranscript": "this is a test",
+  "recentIntentSummaryView": null,
+  "sentimentResponse": {
+    "sentimentLabel": "NEGATIVE",
+    "sentimentScore": "{Positive: 3.8673697E-4,Negative: 0.97321737,Neutral: 0.026389739,Mixed: 6.2867725E-6}"
+  },
+  "kendraResponse": null
+}


### PR DESCRIPTION
* Default both `request_attributes` and `session_attributes`
  to an empty Hash when the values from the event are `null`.
  It is much easier to reason and write logic when you can
  assume that these values are always at least a hash.
* Release version 3.1.0.