### PR TITLE
fix(deps): Remove Implicit ActiveSupport Dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+# 4.0.1 - July 16, 2021
+
+* Fix a bug with the `Aws::Lex::Conversation::Handler::Echo` class because it
+  didn't correctly return an array of messages required for Lex V2.
+* Drop a call to `Hash#deep_symbolize_keys` so we don't implicitly rely on
+  ActiveSupport.
+* Call `Hash#compact` when transforming a Lex response so we don't include any
+  `nil` values in the response.
+
+# 4.0.0 - July 14, 2021
+
+**breaking change** - Drop support for the Lex runtime version 1. If you are using Lex Version 1, please lock this gem to `~> 3.0.0`.
+**breaking change** - Implement support and types for [Lex Version 2](https://docs.aws.amazon.com/lexv2/latest/dg/what-is.html), which implements a new Lambda [input/output event format](https://docs.aws.amazon.com/lexv2/latest/dg/lambda.html#lambda-input-format).
+
+# 3.1.0 - June 1, 2021
+
+* Default both `request_attributes` and `session_attributes`
+  to an empty Hash when the values from the event are `null`.
+  It is much easier to reason and write logic when you can
+  assume that these values are always at least a hash.
+
+# 3.0.0 - May 20, 2021
+
+* **breaking change** - Don't pass the `recentIntentSummaryView` back
+  in the Lex response unless we have modified or added an existing
+  checkpoint. Lex will persist the previous intent summary/history
+  if we do not send a `recentIntentSummaryView` value back in the
+  response (see [1]).
+* Add a few helper methods to the `Aws::Lex::Conversation::Type::Slot`
+  instances:
+
+  - `active?`: returns true if the slot is defined (either optional or
+             required) for the current intent.
+  - `requestable?`: returns true if the slot is active for the current
+                  intent and it is not filled.
+
+[1]: https://docs.aws.amazon.com/lex/latest/dg/lambda-input-response-format.html#lambda-response-recentIntentSummaryView
+
 # 2.0.0 - August 19, 2020
 
 * **breaking change:** Rename `Aws::Lex::Conversation::Type::CurrentIntent` to `Aws::Lex::Conversation::Type::Intent`.

--- a/lib/aws/lex/conversation/handler/echo.rb
+++ b/lib/aws/lex/conversation/handler/echo.rb
@@ -11,10 +11,12 @@ module Aws
             fulfillment_state = options.fetch(:fulfillment_state) { Type::FulfillmentState.new('Fulfilled') }
             conversation.close(
               fulfillment_state: fulfillment_state,
-              message: Type::Message.new(
-                content: content,
-                content_type: content_type
-              )
+              messages: [
+                Type::Message.new(
+                  content: content,
+                  content_type: content_type
+                )
+              ]
             )
           end
         end

--- a/lib/aws/lex/conversation/type/base.rb
+++ b/lib/aws/lex/conversation/type/base.rb
@@ -26,10 +26,11 @@ module Aws
             end
 
             def to_lex
-              self.class.attributes.each_with_object({}) do |attribute, hash|
+              output = self.class.attributes.each_with_object({}) do |attribute, hash|
                 value = transform_to_lex(public_send(attribute))
                 hash[self.class.mapping.fetch(attribute)] = value
               end
+              output.compact
             end
 
             private
@@ -40,9 +41,10 @@ module Aws
                 if value.respond_to?(:to_lex)
                   value.to_lex
                 else
-                  value.each_with_object({}) do |(key, val), hash|
+                  output = value.each_with_object({}) do |(key, val), hash|
                     hash[key.to_sym] = transform_to_lex(val)
                   end
+                  output.compact
                 end
               when Array
                 value.map { |v| transform_to_lex(v) }
@@ -66,7 +68,7 @@ module Aws
             end
 
             def symbolize_hash!
-              ->(v) { v.deep_transform_keys(&:to_sym) }
+              ->(v) { v.transform_keys(&:to_sym) }
             end
 
             def computed_property(attribute, callable)

--- a/lib/aws/lex/conversation/type/intent.rb
+++ b/lib/aws/lex/conversation/type/intent.rb
@@ -22,13 +22,13 @@ module Aws
             end
 
             instance.raw_slots.each_with_object(default_hash) do |(key, value), hash|
-              value ||= { shape: 'Scalar' }
+              normalized = value&.transform_keys(&:to_sym) || { shape: 'Scalar' }
               hash[key.to_sym] = Slot.shrink_wrap(
                 active: true,
                 name: key,
-                shape: value[:shape],
-                value: value[:value],
-                values: value[:values]
+                shape: normalized[:shape],
+                value: normalized[:value],
+                values: normalized[:values]
               )
             end
           end

--- a/lib/aws/lex/conversation/type/session_attributes.rb
+++ b/lib/aws/lex/conversation/type/session_attributes.rb
@@ -10,12 +10,10 @@ module Aws
           optional :checkpoints
 
           def checkpoints
-            @checkpoints ||= begin # rubocop:disable Style/RedundantBegin
-              JSON.parse(
-                Base64.urlsafe_decode64(fetch(:checkpoints) { Base64.urlsafe_encode64([].to_json, padding: false) })
-              ).map do |checkpoint|
-                Checkpoint.shrink_wrap(checkpoint)
-              end
+            @checkpoints ||= JSON.parse(
+              Base64.urlsafe_decode64(fetch(:checkpoints) { Base64.urlsafe_encode64([].to_json, padding: false) })
+            ).map do |checkpoint|
+              Checkpoint.shrink_wrap(checkpoint)
             end
           end
 

--- a/lib/aws/lex/conversation/type/session_state.rb
+++ b/lib/aws/lex/conversation/type/session_state.rb
@@ -16,7 +16,7 @@ module Aws
             active_contexts: Array[Context],
             dialog_action: DialogAction,
             intent: Intent,
-            session_attributes: ->(v) { SessionAttributes[v.deep_symbolize_keys] }
+            session_attributes: ->(v) { SessionAttributes[v.transform_keys(&:to_sym)] }
           )
         end
       end

--- a/lib/aws/lex/conversation/type/slot_value.rb
+++ b/lib/aws/lex/conversation/type/slot_value.rb
@@ -14,6 +14,14 @@ module Aws
           alias_method :value, :interpreted_value
           alias_method :value=, :interpreted_value=
 
+          def to_lex
+            {
+              interpretedValue: interpreted_value,
+              originalValue: original_value,
+              resolvedValues: resolved_values
+            }
+          end
+
           def resolve!(index: 0)
             self.interpreted_value = resolved(index: index)
           end

--- a/lib/aws/lex/conversation/version.rb
+++ b/lib/aws/lex/conversation/version.rb
@@ -3,7 +3,7 @@
 module Aws
   module Lex
     class Conversation
-      VERSION = '4.0.0'
+      VERSION = '4.0.1'
     end
   end
 end

--- a/spec/aws/lex/conversation/handler/echo_spec.rb
+++ b/spec/aws/lex/conversation/handler/echo_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+describe Aws::Lex::Conversation::Handler::Echo do
+  let(:lambda_context) { build(:context) }
+  let(:event) { parse_fixture('events/intents/basic.json') }
+  let(:conversation) { Aws::Lex::Conversation.new(event: event, context: lambda_context) }
+
+  describe '#response' do
+    let(:response) { subject.response(conversation) }
+    let(:messages) { response[:messages].map { |m| m[:content] } }
+
+    it 'returns a Close response' do
+      expect(response.dig(:sessionState, :dialogAction, :type)).to eq('Close')
+    end
+
+    it 'returns a message of the input transcript' do
+      expect(messages).to include(event['inputTranscript'])
+    end
+  end
+end

--- a/spec/aws/lex/conversation/support/mixins/slot_elicitation_spec.rb
+++ b/spec/aws/lex/conversation/support/mixins/slot_elicitation_spec.rb
@@ -69,10 +69,8 @@ describe Aws::Lex::Conversation::Support::Mixins::SlotElicitation do
               },
               intent: {
                 confirmationState: 'None',
-                kendraResponse: nil,
                 name: 'Lex_Intent_Echo',
                 nluConfidence: 1.0,
-                originatingRequestId: nil,
                 slots: {
                   HasACat: {
                     shape: 'Scalar',
@@ -112,15 +110,12 @@ describe Aws::Lex::Conversation::Support::Mixins::SlotElicitation do
               sessionState: {
                 activeContexts: [],
                 dialogAction: {
-                  slotToElicit: nil,
                   type: 'Close'
                 },
                 intent: {
                   confirmationState: 'None',
-                  kendraResponse: nil,
                   name: 'Lex_Intent_Echo',
                   nluConfidence: 1.0,
-                  originatingRequestId: nil,
                   slots: {
                     HasACat: {
                       shape: 'Scalar',
@@ -167,10 +162,8 @@ describe Aws::Lex::Conversation::Support::Mixins::SlotElicitation do
               },
               intent: {
                 confirmationState: 'None',
-                kendraResponse: nil,
                 name: 'Lex_Intent_Echo',
                 nluConfidence: 1.0,
-                originatingRequestId: nil,
                 slots: {
                   HasACat: {
                     shape: 'Scalar',


### PR DESCRIPTION
* Fix a bug with the `Aws::Lex::Conversation::Handler::Echo` class because it
  didn't correctly return an array of messages required for Lex V2.
* Drop a call to `Hash#deep_symbolize_keys` so we don't implicitly rely on
  ActiveSupport.
* Call `Hash#compact` when transforming a Lex response so we don't include any
  `nil` values in the response.