### PR TITLE
fix(response) - Delegate/ElicitIntent Responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.1.0 - July 21, 2021
+
+* Don't set the `intent` property in the response for `ElicitIntent`
+  actions as the field is optional as per [AWS documentation](https://docs.aws.amazon.com/lexv2/latest/dg/lambda.html#lambda-response-format).
+* Add `InProgress` and `ReadyForFulfillment` enumerations to `FulfillmentState`.
+
 # 4.0.1 - July 16, 2021
 
 * Fix a bug with the `Aws::Lex::Conversation::Handler::Echo` class because it

--- a/lib/aws/lex/conversation/response/elicit_intent.rb
+++ b/lib/aws/lex/conversation/response/elicit_intent.rb
@@ -10,6 +10,8 @@ module Aws
           def initialize(opts = {})
             super
             session_state.dialog_action = dialog_action
+            # by default, we set intent as nil unless overridden
+            session_state.intent = opts[:intent]
           end
 
           def dialog_action

--- a/lib/aws/lex/conversation/type/fulfillment_state.rb
+++ b/lib/aws/lex/conversation/type/fulfillment_state.rb
@@ -9,6 +9,8 @@ module Aws
 
           enumeration('Fulfilled')
           enumeration('Failed')
+          enumeration('InProgress')
+          enumeration('ReadyForFulfillment')
         end
       end
     end

--- a/lib/aws/lex/conversation/version.rb
+++ b/lib/aws/lex/conversation/version.rb
@@ -3,7 +3,7 @@
 module Aws
   module Lex
     class Conversation
-      VERSION = '4.0.2'
+      VERSION = '4.1.0'
     end
   end
 end


### PR DESCRIPTION
* AWS documentation mentions that the `intent` block in the response
  is optional for the `ElicitIntent` action [1]. In practice
  we don't want to send this field back in the response as it can cause
  errors in the Lex service (i.e. we sent back an invalid intent
  state field for the action).
* Add `ReadyForFulfillment` and `InProgress` as enumerations
  for for `FulfillmentState` as they were added in the V2 release.

[1]: https://docs.aws.amazon.com/lexv2/latest/dg/lambda.html#lambda-response-format