### PR TITLE
ADO 28018: Allow content_type to optionally be a proc

### DIFF
--- a/lib/aws/lex/conversation/slot/elicitation.rb
+++ b/lib/aws/lex/conversation/slot/elicitation.rb
@@ -29,11 +29,15 @@ module Aws
               slot_to_elicit: name,
               messages: [
                 {
-                  contentType: content_type,
+                  contentType: message_content_type,
                   content: elicitation_content
                 }
               ]
             )
+          end
+
+          def message_content_type
+            content_type.is_a?(Proc) ? content_type.call(conversation) : content_type
           end
 
           def elicit?

--- a/lib/aws/lex/conversation/version.rb
+++ b/lib/aws/lex/conversation/version.rb
@@ -3,7 +3,7 @@
 module Aws
   module Lex
     class Conversation
-      VERSION = '4.1.0'
+      VERSION = '4.2.0'
     end
   end
 end


### PR DESCRIPTION
See: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/28018

* allow content_type to be a proc or a standard object