### PR TITLE
Slot elicitor DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.3.0 - August 25, 2021
+
+* Slot elicitor can now be passed an Aws::Lex::Conversation::Type::Message as part of the DSL/callback and properly formats the response as such
+
 # 4.1.0 - July 21, 2021
 
 * Don't set the `intent` property in the response for `ElicitIntent`

--- a/lib/aws/lex/conversation/slot/elicitation.rb
+++ b/lib/aws/lex/conversation/slot/elicitation.rb
@@ -28,10 +28,7 @@ module Aws
             conversation.elicit_slot(
               slot_to_elicit: name,
               messages: [
-                {
-                  contentType: message_content_type,
-                  content: elicitation_content
-                }
+                elicitation_message
               ]
             )
           end
@@ -50,12 +47,21 @@ module Aws
             conversation.slots[name.to_sym]
           end
 
-          def elicitation_content
+          def elicitation_message
             first_elicitation? ? compose_message(message) : compose_message(follow_up_message)
           end
 
           def compose_message(msg)
-            msg.is_a?(Proc) ? msg.call(conversation) : msg
+            content = msg.is_a?(Proc) ? msg.call(conversation) : msg
+
+            if content.is_a?(Aws::Lex::Conversation::Type::Message)
+              content
+            else
+              {
+                content: content,
+                contentType: message_content_type
+              }
+            end
           end
 
           def increment_slot_elicitations!

--- a/lib/aws/lex/conversation/version.rb
+++ b/lib/aws/lex/conversation/version.rb
@@ -3,7 +3,7 @@
 module Aws
   module Lex
     class Conversation
-      VERSION = '4.2.0'
+      VERSION = '4.3.0'
     end
   end
 end

--- a/spec/aws/lex/conversation/slot/elicitation_spec.rb
+++ b/spec/aws/lex/conversation/slot/elicitation_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+describe Aws::Lex::Conversation::Slot::Elicitation do
+  let(:event) { parse_fixture('events/intents/elicit.json') }
+  let(:lambda_context) { build(:context) }
+  let(:conversation) { Aws::Lex::Conversation.new(event: event, context: lambda_context) }
+
+  subject do
+    described_class.new(
+      name: 'HasACat',
+      maximum_elicitations: 1,
+      message: message,
+      content_type: 'PlainText',
+      follow_up_message: 'Do you have a feline?',
+      fallback: fallback
+    )
+  end
+
+  before(:each) do
+    subject.conversation = conversation
+  end
+
+  describe '#elicit!' do
+    let(:message) { 'Do you have a cat?' }
+    let(:fallback) do
+      ->(c) do
+        c.close(
+          fulfillment_state: 'Failed',
+          messages: [
+            {
+              content: 'I give up.',
+              contentType: 'PlainText'
+            }
+          ]
+        )
+      end
+    end
+
+    context 'with the first iteration' do
+      it 'returns the first elicitation message' do
+        expect(subject.elicit![:messages][0][:content]).to eq('Do you have a cat?')
+      end
+
+      context 'when the message is an instance of Aws::Lex::Conversation::Type::Message' do
+        let(:message) do
+          ->(_) do
+            Aws::Lex::Conversation::Type::Message.new(
+              content: '<speak>Do you have a cat?</speak>',
+              contentType: 'SSML'
+            )
+          end
+        end
+
+        it 'returns the first elicitation message' do
+          expect(subject.elicit![:messages][0][:content]).to eq('<speak>Do you have a cat?</speak>')
+        end
+      end
+    end
+
+    context 'with the second iteration' do
+      before(:each) do
+        subject.elicit!
+      end
+
+      it 'returns the follow_up_message' do
+        expect(subject.elicit![:messages][0][:content]).to eq('Do you have a feline?')
+      end
+    end
+
+    context 'when maximum_elicitations are exceeded' do
+      before(:each) do
+        2.times { subject.elicit! }
+      end
+
+      it 'returns the fallback content' do
+        response = subject.elicit!
+
+        expect(response[:messages][0][:content]).to eq('I give up.')
+        expect(response[:sessionState][:dialogAction][:type]).to eq('Close')
+      end
+
+      context 'when the fallback callback returns an Aws::Lex::Conversation::Type::Message' do
+        let(:fallback) do
+          ->(c) do
+            c.close(
+              fulfillment_state: 'Failed',
+              messages: [
+                Aws::Lex::Conversation::Type::Message.new(
+                  content: '<speak>Fallback</speak>',
+                  content_type: Aws::Lex::Conversation::Type::Message::ContentType.new('SSML')
+                )
+              ]
+            )
+          end
+        end
+
+        it 'returns the fallback content' do
+          response = subject.elicit!
+
+          expect(response[:messages][0][:content]).to eq('<speak>Fallback</speak>')
+          expect(response[:messages][0][:contentType]).to eq('SSML')
+          expect(response[:sessionState][:dialogAction][:type]).to eq('Close')
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/events/intents/elicit.json
+++ b/spec/fixtures/events/intents/elicit.json
@@ -1,0 +1,97 @@
+{
+  "sessionId": "1234",
+  "requestAttributes": {},
+  "inputTranscript": "waffle",
+  "interpretations": [
+    {
+      "intent": {
+        "slots": {
+          "HasACat": {
+            "shape": "Scalar",
+            "value": null
+          }
+        },
+        "confirmationState": "None",
+        "name": "Lex_V2_Intent_A",
+        "state": "ReadyForFulfillment"
+      },
+      "nluConfidence": 1,
+      "sentimentResponse": {
+        "sentiment": "NEUTRAL",
+        "sentimentScore": {
+          "mixed": 1.3306875E-5,
+          "negative": 0.0038302848,
+          "neutral": 0.9676958,
+          "positive": 0.028460732
+        }
+      }
+    },
+    {
+      "intent": {
+        "slots": {},
+        "confirmationState": "None",
+        "name": "Lex_V2_FallbackIntent",
+        "state": "ReadyForFulfillment"
+      }
+    },
+    {
+      "intent": {
+        "slots": {},
+        "confirmationState": "None",
+        "name": "Lex_V2_Intent_B",
+        "state": "ReadyForFulfillment"
+      },
+      "nluConfidence": 0.58
+    },
+    {
+      "intent": {
+        "slots": {},
+        "confirmationState": "None",
+        "name": "Lex_V2_Intent_C",
+        "state": "ReadyForFulfillment"
+      },
+      "nluConfidence": 0.45
+    },
+    {
+      "intent": {
+        "slots": {},
+        "confirmationState": "None",
+        "name": "Lex_V2_Intent_D",
+        "state": "ReadyForFulfillment"
+      },
+      "nluConfidence": 0.43
+    }
+  ],
+  "responseContentType": "text/plain; charset=utf-8",
+  "invocationSource": "DialogCodeHook",
+  "messageVersion": "1.0",
+  "sessionState": {
+    "sessionAttributes": {
+      "foo": "NO",
+      "bar": "231234215125",
+      "baz": "Apples"
+    },
+    "activeContexts": [],
+    "intent": {
+      "slots": {
+        "HasACat": {
+          "shape": "Scalar",
+          "value": null
+        }
+      },
+      "confirmationState": "None",
+      "name": "Lex_V2_Intent_A",
+      "state": "InProgress"
+    },
+    "originatingRequestId": "d6349818-c9a1-463e-b8e6-7fcdc5169b71"
+  },
+  "inputMode": "Text",
+  "bot": {
+    "aliasName": "TestBotAlias",
+    "aliasId": "TSTALIASID",
+    "name": "LexBot",
+    "version": "DRAFT",
+    "localeId": "en_US",
+    "id": "YR23299542f"
+  }
+}


### PR DESCRIPTION
* Slot elicitor can now be passed an Aws::Lex::Conversation::Type::Message as part of the DSL/callback and properly formats the response as such