### PR TITLE
ADO 28027: Slot elicitors take an array of messages

### DIFF
--- a/lib/aws/lex/conversation/version.rb
+++ b/lib/aws/lex/conversation/version.rb
@@ -3,7 +3,7 @@
 module Aws
   module Lex
     class Conversation
-      VERSION = '4.3.0'
+      VERSION = '5.0.0'
     end
   end
 end

--- a/spec/fixtures/classes/slot_elicitation_handler.rb
+++ b/spec/fixtures/classes/slot_elicitation_handler.rb
@@ -5,8 +5,18 @@ class SlotElicitationHandler < Aws::Lex::Conversation::Handler::Echo
 
   slot name: 'HasACat',
        elicit: ->(conversation) { conversation.session[:elicit_slot] == true },
-       message: 'Do you have a cat?',
-       follow_up_message: 'Sorry, I did not understand you. Do you have a cat?',
+       messages: [
+         Aws::Lex::Conversation::Type::Message.new(
+           content: 'Do you have a cat?',
+           content_type: 'PlainText'
+         )
+       ],
+       follow_up_messages: [
+         Aws::Lex::Conversation::Type::Message.new(
+           content: 'Sorry, I did not understand you. Do you have a cat?',
+           content_type: 'PlainText'
+         )
+       ],
        fallback: ->(conversation) do
          conversation.close(
            fulfillment_state: 'Failed',


### PR DESCRIPTION
See: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/28027

* breaking change
* slot elicitors take an array of messages and follow-up messages
* allow nil fallback and simply don't elicit the slot if max attempts
  have been exceeded in those cases