### PR TITLE
ADO 28659: Checkpoints should always set the intent

### DIFF
--- a/lib/aws/lex/conversation/support/mixins/responses.rb
+++ b/lib/aws/lex/conversation/support/mixins/responses.rb
@@ -9,8 +9,10 @@ module Aws
             def close(opts = {})
               params = {
                 session_state: lex.session_state,
-                request_attributes: lex.request_attributes
+                request_attributes: lex.request_attributes,
+                intent: lex.current_intent
               }.merge(opts)
+              lex.session_state.intent = params.fetch(:intent)
               Response::Close.new(params).to_lex
             end
 
@@ -27,16 +29,20 @@ module Aws
             def delegate(opts = {})
               params = {
                 session_state: lex.session_state,
-                request_attributes: lex.request_attributes
+                request_attributes: lex.request_attributes,
+                intent: lex.current_intent
               }.merge(opts)
+              lex.session_state.intent = params.fetch(:intent)
               Response::Delegate.new(params).to_lex
             end
 
             def elicit_intent(opts = {})
               params = {
                 session_state: lex.session_state,
-                request_attributes: lex.request_attributes
+                request_attributes: lex.request_attributes,
+                intent: lex.current_intent
               }.merge(opts)
+              lex.session_state.intent = params.fetch(:intent)
               Response::ElicitIntent.new(params).to_lex
             end
 

--- a/lib/aws/lex/conversation/type/checkpoint.rb
+++ b/lib/aws/lex/conversation/type/checkpoint.rb
@@ -20,11 +20,12 @@ module Aws
             fulfillment_state: FulfillmentState
           )
 
-          # rubocop:disable Metrics/MethodLength
+          # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
           def restore(conversation, opts = {})
             case dialog_action_type.raw
             when 'Close'
               conversation.close(
+                intent: intent,
                 fulfillment_state: opts.fetch(:fulfillment_state) { fulfillment_state },
                 messages: opts.fetch(:messages)
               )
@@ -34,9 +35,12 @@ module Aws
                 messages: opts.fetch(:messages)
               )
             when 'Delegate'
-              conversation.delegate
+              conversation.delegate(
+                intent: intent
+              )
             when 'ElicitIntent'
               conversation.elicit_intent(
+                intent: intent,
                 messages: opts.fetch(:messages)
               )
             when 'ElicitSlot'
@@ -49,7 +53,7 @@ module Aws
               raise ArgumentError, "invalid DialogActionType: `#{dialog_action_type.raw}`"
             end
           end
-          # rubocop:enable Metrics/MethodLength
+          # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
         end
       end
     end

--- a/lib/aws/lex/conversation/version.rb
+++ b/lib/aws/lex/conversation/version.rb
@@ -3,7 +3,7 @@
 module Aws
   module Lex
     class Conversation
-      VERSION = '5.0.0'
+      VERSION = '5.1.0'
     end
   end
 end


### PR DESCRIPTION
See: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/28659

* always override the currrent intent on checkpoint restoration