### PR TITLE
ADO 28659: Ensure SessionAttributes is coerced to a hash for Lex

### DIFF
--- a/lib/aws/lex/conversation/type/session_attributes.rb
+++ b/lib/aws/lex/conversation/type/session_attributes.rb
@@ -20,7 +20,7 @@ module Aws
           def to_lex
             merge(
               checkpoints: Base64.urlsafe_encode64(checkpoints.map(&:to_lex).to_json, padding: false)
-            )
+            ).to_h
           end
         end
       end

--- a/lib/aws/lex/conversation/version.rb
+++ b/lib/aws/lex/conversation/version.rb
@@ -3,7 +3,7 @@
 module Aws
   module Lex
     class Conversation
-      VERSION = '5.1.0'
+      VERSION = '5.1.1'
     end
   end
 end


### PR DESCRIPTION
See: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/28659

* to_lex operations should always return a hash for session attributes
  or we may run into issues with serialization