### PR TITLE
30402 - Fix Slot Elicitation Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
+# 6.1.1 - Sept 22, 2021
+
+* renamed `maximum_elicitations` to `max_retries` and made it backwards compatible to make the param name clear, by default this value is zero, allowing each slot to elicit only once
+
 # 6.1.0 - Sept 7, 2021
+
 Added helper methods for clearing active contexts
+
 ```ruby
 conversation.clear_context!(name: 'test') # clears this specific active context
 conversation.clear_all_contexts! # clears all current active contexts
 ```
-
 
 # 6.0.0 - Sept 7, 2021
 
@@ -63,6 +68,7 @@ it 'creates an event' do
   expect(event).to include_session_values(username: 'jane.doe')
 end
 ```
+
 * Add a few convenience methods to `Aws::Lex::Conversation` instances for dealing with active contexts:
   - `#active_context(name:)`:
 

--- a/lib/aws/lex/conversation/slot/elicitation.rb
+++ b/lib/aws/lex/conversation/slot/elicitation.rb
@@ -6,7 +6,7 @@ module Aws
       module Slot
         class Elicitation
           attr_accessor :name, :elicit, :messages, :follow_up_messages,
-                        :fallback, :maximum_elicitations, :conversation
+                        :fallback, :max_retries, :conversation
 
           def initialize(opts = {})
             self.name = opts.fetch(:name)
@@ -14,7 +14,7 @@ module Aws
             self.messages = opts.fetch(:messages)
             self.follow_up_messages = opts.fetch(:follow_up_messages) { opts.fetch(:messages) }
             self.fallback = opts[:fallback]
-            self.maximum_elicitations = opts.fetch(:maximum_elicitations) { 0 }
+            self.max_retries = opts[:max_retries] || opts[:maximum_elicitations] || 0
           end
 
           def elicit!
@@ -53,9 +53,7 @@ module Aws
           end
 
           def maximum_elicitations?
-            return false if maximum_elicitations.zero?
-
-            elicitation_attempts > maximum_elicitations
+            elicitation_attempts > max_retries
           end
 
           def first_elicitation?

--- a/lib/aws/lex/conversation/type/slot.rb
+++ b/lib/aws/lex/conversation/type/slot.rb
@@ -32,7 +32,7 @@ module Aws
           def value
             raise TypeError, 'use values for List-type slots' if shape.list?
 
-            lex_value.interpreted_value
+            lex_value&.interpreted_value
           end
 
           # takes an array of slot values

--- a/lib/aws/lex/conversation/version.rb
+++ b/lib/aws/lex/conversation/version.rb
@@ -3,7 +3,7 @@
 module Aws
   module Lex
     class Conversation
-      VERSION = '6.1.0'
+      VERSION = '6.1.1'
     end
   end
 end

--- a/spec/aws/lex/conversation/slot/elicitation_spec.rb
+++ b/spec/aws/lex/conversation/slot/elicitation_spec.rb
@@ -4,6 +4,7 @@ describe Aws::Lex::Conversation::Slot::Elicitation do
   let(:event) { parse_fixture('events/intents/elicit.json') }
   let(:lambda_context) { build(:context) }
   let(:conversation) { Aws::Lex::Conversation.new(event: event, context: lambda_context) }
+  let(:max_retries) { 1 }
 
   let(:follow_up_messages) do
     [
@@ -17,7 +18,7 @@ describe Aws::Lex::Conversation::Slot::Elicitation do
   subject do
     described_class.new(
       name: 'HasACat',
-      maximum_elicitations: 1,
+      max_retries: max_retries,
       messages: messages,
       follow_up_messages: follow_up_messages,
       fallback: fallback
@@ -51,84 +52,109 @@ describe Aws::Lex::Conversation::Slot::Elicitation do
       end
     end
 
-    context 'with the first iteration' do
-      it 'returns the first elicitation message' do
-        expect(subject.elicit!).to have_message(content: 'Do you have a cat?')
-      end
-
-      context 'when the message is an instance of Aws::Lex::Conversation::Type::Message' do
-        let(:messages) do
-          ->(_) do
-            [
-              Aws::Lex::Conversation::Type::Message.new(
-                content: 'Do you have a cat?',
-                content_type: 'PlainText'
-              )
-            ]
-          end
+    context 'with 1 max_retries' do
+      context 'with the first iteration' do
+        it 'returns the first elicitation message' do
+          expect(subject.elicit!).to have_message(content: 'Do you have a cat?')
         end
 
+        context 'when the message is an instance of Aws::Lex::Conversation::Type::Message' do
+          let(:messages) do
+            ->(_) do
+              [
+                Aws::Lex::Conversation::Type::Message.new(
+                  content: 'Do you have a cat?',
+                  content_type: 'PlainText'
+                )
+              ]
+            end
+          end
+
+          it 'returns the first elicitation message' do
+            expect(subject.elicit!).to have_message(content: 'Do you have a cat?')
+          end
+        end
+      end
+
+      context 'with the second iteration' do
+        before(:each) do
+          subject.elicit!
+        end
+
+        it 'returns the follow_up_message' do
+          expect(subject.elicit!).to have_message(content: 'Do you have a feline?')
+        end
+      end
+
+      context 'when max_retries are exceeded' do
+        before(:each) do
+          2.times { subject.elicit! }
+        end
+
+        it 'returns the fallback content' do
+          response = subject.elicit!
+
+          expect(response).to have_message(content: 'I give up.')
+          expect(response).to have_action('Close')
+        end
+
+        context 'when the fallback callback returns an Aws::Lex::Conversation::Type::Message' do
+          context 'when there is a fallback' do
+            let(:fallback) do
+              ->(c) do
+                c.close(
+                  fulfillment_state: 'Failed',
+                  messages: [
+                    Aws::Lex::Conversation::Type::Message.new(
+                      content: '<speak>Fallback</speak>',
+                      content_type: Aws::Lex::Conversation::Type::Message::ContentType.new('SSML')
+                    )
+                  ]
+                )
+              end
+            end
+
+            it 'returns the fallback content' do
+              response = subject.elicit!
+
+              expect(response).to have_message(
+                content: '<speak>Fallback</speak>',
+                contentType: 'SSML'
+              )
+              expect(response).to have_action('Close')
+            end
+          end
+
+          context 'when there is not a fallback' do
+            let(:fallback) { nil }
+
+            it 'will not elicit' do
+              expect(subject.elicit!).to eq(false)
+            end
+          end
+        end
+      end
+    end
+
+    context 'with 0 max_retries' do
+      let(:max_retries) { 0 }
+
+      context 'with the first iteration' do
         it 'returns the first elicitation message' do
           expect(subject.elicit!).to have_message(content: 'Do you have a cat?')
         end
       end
-    end
 
-    context 'with the second iteration' do
-      before(:each) do
-        subject.elicit!
-      end
-
-      it 'returns the follow_up_message' do
-        expect(subject.elicit!).to have_message(content: 'Do you have a feline?')
-      end
-    end
-
-    context 'when maximum_elicitations are exceeded' do
-      before(:each) do
-        2.times { subject.elicit! }
-      end
-
-      it 'returns the fallback content' do
-        response = subject.elicit!
-
-        expect(response).to have_message(content: 'I give up.')
-        expect(response).to have_action('Close')
-      end
-
-      context 'when the fallback callback returns an Aws::Lex::Conversation::Type::Message' do
-        context 'when there is a fallback' do
-          let(:fallback) do
-            ->(c) do
-              c.close(
-                fulfillment_state: 'Failed',
-                messages: [
-                  Aws::Lex::Conversation::Type::Message.new(
-                    content: '<speak>Fallback</speak>',
-                    content_type: Aws::Lex::Conversation::Type::Message::ContentType.new('SSML')
-                  )
-                ]
-              )
-            end
-          end
-
-          it 'returns the fallback content' do
-            response = subject.elicit!
-
-            expect(response).to have_message(
-              content: '<speak>Fallback</speak>',
-              contentType: 'SSML'
-            )
-            expect(response).to have_action('Close')
-          end
+      context 'when max_retries are exceeded' do
+        before(:each) do
+          subject.elicit!
         end
 
-        context 'when there is not a fallback' do
-          let(:fallback) { nil }
+        it 'returns the fallback content' do
+          response = subject.elicit!
 
-          it 'will not elicit' do
-            expect(subject.elicit!).to eq(false)
-          end
+          expect(response).to have_message(content: 'I give up.')
+          expect(response).to have_action('Close')
         end
       end
     end

--- a/spec/fixtures/classes/slot_elicitation_handler.rb
+++ b/spec/fixtures/classes/slot_elicitation_handler.rb
@@ -28,5 +28,5 @@ class SlotElicitationHandler < Aws::Lex::Conversation::Handler::Echo
            ]
          )
        end,
-       maximum_elicitations: 2
+       max_retries: 2
 end


### PR DESCRIPTION
🐘

v6.1.1 - Sept 22, 2021

* renamed `maximum_elicitations` to `max_retries` and made it backwards compatible to make the param name clear, by default this value is zero, allowing each slot to elicit once

- Set the version to 6.1.1
- Updated the changelog
- changed the param name, added additional tests

https://dev.azure.com/AMA-Ent/AMA-Ent/_boards/board/t/Red%20Team/Stories/?workitem=27756
https://dev.azure.com/AMA-Ent/AMA-Ent/_boards/board/t/Red%20Team/Stories/?workitem=30402