### PR TITLE
Active Context Clearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 6.1.0 - Sept 7, 2021
+Added helper methods for clearing active contexts
+```ruby
+conversation.clear_context!(name: 'test') # clears this specific active context
+conversation.clear_all_contexts! # clears all current active contexts
+```
+
+
 # 6.0.0 - Sept 7, 2021
 
 * **breaking change** - Modify `Aws::Lex::Conversation::Type::Base#computed_property` to accept a block instead of a callable argument. This is an internal class and should not require any application-level changes.

--- a/lib/aws/lex/conversation.rb
+++ b/lib/aws/lex/conversation.rb
@@ -120,6 +120,14 @@ module Aws
         instance
       end
 
+      def clear_context!(name:)
+        lex.session_state.active_contexts.delete_if { |c| c.name == name }
+      end
+
+      def clear_all_contexts!
+        lex.session_state.active_contexts = []
+      end
+
       def stash
         @stash ||= {}
       end

--- a/lib/aws/lex/conversation/version.rb
+++ b/lib/aws/lex/conversation/version.rb
@@ -3,7 +3,7 @@
 module Aws
   module Lex
     class Conversation
-      VERSION = '6.0.0'
+      VERSION = '6.1.0'
     end
   end
 end

--- a/spec/aws/lex/conversation_spec.rb
+++ b/spec/aws/lex/conversation_spec.rb
@@ -62,6 +62,23 @@ describe Aws::Lex::Conversation do
         expect(instance.time_to_live.turns_to_live).to eq(2)
         expect(instance.context_attributes).to eq(foo: 'bar')
       end
+
+      context 'when we delete said active context' do
+        it 'properly deletes the context' do
+          subject.clear_context!(name: 'test')
+
+          instance = subject.active_context(name: 'test')
+          expect(instance).to be(nil)
+        end
+      end
+
+      context 'when we delete all contexts' do
+        it 'there are no active contexts' do
+          subject.clear_all_contexts!
+          instance = subject.active_context(name: 'test')
+          expect(instance).to be(nil)
+        end
+      end
     end
 
     context 'when an active context does not exist' do


### PR DESCRIPTION
* Added helper methods for clearing active contexts
```ruby
conversation.clear_context!(name: 'test') # clears this specific active context
conversation.clear_all_contexts! # clears all current active contexts
```