### PR TITLE
feat(checkpoint): Checkpoint Hydration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 6.2.0 - Sept 28, 2021
+
+* Add a `Aws::Lex::Conversation#restore_from!` method that accepts a checkpoint parameter. This method modifies the underlying conversation state to match the data from the saved checkpoint.
+* Make the `dialog_action_type` parameter on `Aws::Lex::Conversation#checkpoint!` default to `Delegate` if not specified as a developer convenience.
+* Allow developers to pass an optional `intent` override parameter on `Aws::Lex::Conversation#checkpoint!` for convenience.
+* Update the README with advanced examples for the conversation stash and checkpoints.
+
 # 6.1.1 - Sept 22, 2021
 
 * renamed `maximum_elicitations` to `max_retries` and made it backwards compatible to make the param name clear, by default this value is zero, allowing each slot to elicit only once

--- a/README.md
+++ b/README.md
@@ -191,6 +191,114 @@ conversation.handlers = [
 conversation.respond # => { dialogAction: { type: 'Delegate' } }
 ```
 
+## Advanced Concepts
+
+This library provides a few constructs to help manage complex interactions:
+
+### Data Stash
+
+`Aws::Lex::Conversation` instances implement a `stash` method that can be used to store temporary data within a single invocation.
+
+A conversation's stashed data will not be persisted between multiple invocations of your lambda function.
+
+The conversation stash is a great spot to store deserialized data from the session, or invocation-specific state that needs to be shared between handler classes.
+
+This example illustrates how the stash can be used to store deserialized data from the session:
+
+```ruby
+# given we have JSON-serialized data in as a persisted session value
+conversation.session[:user_data] = '{"name":"Jane","id":1234,"email":"test@example.com"}'
+# we can deserialize the data into a Hash that we store in the conversation stash
+conversation.stash[:user] = JSON.parse(conversation.session[:user_data])
+# later on we can reference our stashed data (within the same invocation)
+conversation.stash[:user] # => {"name"=>"Jane", "id"=>1234, "email"=>"test@example.com"}
+```
+
+### Checkpoints
+
+A conversation may transition between many different topics as the interaction progresses. This type of state transition can be easily handled with checkpoints.
+
+When a checkpoint is created, all intent and slot data is encoded and stored into a `checkpoints` session value. This data persist between invocations, and is not removed until the checkpoint is restored.
+
+You can create a checkpoint as follows:
+
+```ruby
+# we're ready to fulfill the OrderFlowers intent, but we want to elicit another intent first
+conversation.checkpoint!(
+  label: 'order_flowers',
+  dialog_action_type: 'Close' # defaults to 'Delegate' if not specified
+)
+conversation.elicit_intent(
+  messages: [
+    {
+      content: 'Thanks! Before I place your order, is there anything else I can help with?',
+      contentType: 'PlainText'
+    }
+  ]
+)
+```
+
+You can restore the checkpoint in one of two ways:
+
+```ruby
+# in a future invocation, we can fetch an instance of the checkpoint and easily
+# restore the conversation to the previous state
+checkpoint = conversation.checkpoint(label: 'order_flowers')
+checkpoint.restore!(
+  fulfillment_state: 'Fulfilled',
+  messages: [
+    {
+      content: 'Okay, your flowers have been ordered! Thanks!',
+      contentType: 'PlainText'
+    }
+  ]
+) # => our response object to Lex is returned
+```
+
+It's also possible to restore state from a checkpoint and utilize the conversation's handler chain:
+
+```ruby
+class AnotherIntent < Aws::Lex::Conversation::Handler::Base
+  def will_respond?(conversation)
+    conversation.intent_name == 'AnotherIntent' &&
+    conversation.checkpoint?(label: 'order_flowers')
+  end
+
+  def response(conversation)
+    checkpoint = conversation.checkpoint(label: 'order_flowers')
+    # replace the conversation's current resolved intent/slot data with the saved checkpoint data
+    conversation.restore_from!(checkpoint)
+    # call the next handler in the chain to produce a response
+    successor.handle(conversation)
+  end
+end
+
+class OrderFlowers < Aws::Lex::Conversation::Handler::Base
+  def will_respond?(conversation)
+    conversation.intent_name == 'OrderFlowers'
+  end
+
+  def response(conversation)
+    conversation.close(
+      fulfillment_state: 'Fulfilled',
+      messages: [
+        {
+          content: 'Okay, your flowers have been ordered! Thanks!',
+          contentType: 'PlainText'
+        }
+      ]
+    )
+  end
+end
+
+conversation = Aws::Lex::Conversation.new(event: event, context: context)
+conversation.handlers = [
+  { handler: AnotherIntent },
+  { handler: OrderFlowers }
+]
+conversation.respond # => returns a Lex response object
+```
+
 ## Test Helpers
 
 This library provides convenience methods to make testing easy! You can use the test helpers as follows:

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ conversation.stash[:user] # => {"name"=>"Jane", "id"=>1234, "email"=>"test@examp
 
 A conversation may transition between many different topics as the interaction progresses. This type of state transition can be easily handled with checkpoints.
 
-When a checkpoint is created, all intent and slot data is encoded and stored into a `checkpoints` session value. This data persist between invocations, and is not removed until the checkpoint is restored.
+When a checkpoint is created, all intent and slot data is encoded and stored into a `checkpoints` session value. This data persists between invocations, and is not removed until the checkpoint is restored.
 
 You can create a checkpoint as follows:
 

--- a/lib/aws/lex/conversation/type/checkpoint.rb
+++ b/lib/aws/lex/conversation/type/checkpoint.rb
@@ -5,6 +5,11 @@ module Aws
     class Conversation
       module Type
         class Checkpoint
+          ENUM_PARAMS = %i[
+            fulfillment_state
+            dialog_action_type
+          ].freeze
+
           include Base
 
           required :dialog_action_type
@@ -19,6 +24,28 @@ module Aws
             dialog_action_type: DialogActionType,
             fulfillment_state: FulfillmentState
           )
+
+          class << self
+            def build(opts = {})
+              new(normalize_parameters(opts))
+            end
+
+            private
+
+            def normalize_parameters(opts)
+              params = opts.dup # we don't want to mutate our arguments
+
+              if params[:dialog_action_type].is_a?(String)
+                params[:dialog_action_type] = DialogActionType.new(params[:dialog_action_type])
+              end
+
+              if params[:fulfillment_state].is_a?(String)
+                params[:fulfillment_state] = FulfillmentState.new(params[:fulfillment_state])
+              end
+
+              params
+            end
+          end
 
           # restore the checkpoint AND remove it from session
           def restore!(conversation, opts = {})

--- a/lib/aws/lex/conversation/type/checkpoint.rb
+++ b/lib/aws/lex/conversation/type/checkpoint.rb
@@ -5,11 +5,6 @@ module Aws
     class Conversation
       module Type
         class Checkpoint
-          ENUM_PARAMS = %i[
-            fulfillment_state
-            dialog_action_type
-          ].freeze
-
           include Base
 
           required :dialog_action_type

--- a/lib/aws/lex/conversation/version.rb
+++ b/lib/aws/lex/conversation/version.rb
@@ -3,7 +3,7 @@
 module Aws
   module Lex
     class Conversation
-      VERSION = '6.1.1'
+      VERSION = '6.2.0'
     end
   end
 end

--- a/spec/aws/lex/conversation_spec.rb
+++ b/spec/aws/lex/conversation_spec.rb
@@ -190,6 +190,31 @@ describe Aws::Lex::Conversation do
     end
   end
 
+  describe '#restore_from!' do
+    let(:checkpoint) { subject.checkpoint(label: 'order_flowers') }
+
+    before(:each) do
+      subject
+        .simulate!
+        .intent(name: 'OrderFlowers')
+        .slot(name: 'Type', value: 'lillies')
+      subject.checkpoint!(label: 'order_flowers')
+      subject
+        .simulate!
+        .intent(name: 'OutroIntent')
+    end
+
+    it 'modifies the intent to match checkpoint data' do
+      expect(subject.intent_name).to eq('OutroIntent')
+      subject.restore_from!(checkpoint)
+      expect(subject.intent_name).to eq('OrderFlowers')
+    end
+
+    it 'returns the conversation instance' do
+      expect(subject.restore_from!(checkpoint)).to eq(subject)
+    end
+  end
+
   describe '#respond' do
     let(:response) { subject.respond }
 


### PR DESCRIPTION
* Add a `Aws::Lex::Conversation#restore_from!` method that accepts
  a checkpoint parameter. This method modifies the underlying
  conversation state to match the data from the saved checkpoint.
* The primary use-case of the `restore_from!` method is to restore
  ("rehydrate") conversation state from a checkpoint, then utilize
  the standard conversation handler chain to generate a response
  to the user.
* Make the `dialog_action_type` parameter on
  `Aws::Lex::Conversation#checkpoint!` default to `Delegate` if
  not specified as a developer convenience.
* Allow developers to pass an optional `intent` override parameter on
  `Aws::Lex::Conversation#checkpoint!` as a convenience.
* Update the README with advanced examples for the conversation
  stash and checkpoints.