### PR TITLE
fix(transcriptions): Fix Transcription ResolvedSlot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.4.1 - Feb 10, 2022
+
+* There was a bug with the way we were building the structure for the `resolved_slots` with the recent release of transcription confidence scores in 6.4.0.
+* The bug would result in an `ArgumentError` being raised during the input event validation phase when creating a conversation instance.
+* To resolve this bug, we now correctly coerce the `resolved_slots` value as a Hash.
+
 # 6.4.0 - Feb 10, 2022
 
 * Add support for the new protocol properties of `proposedNextState` and `transcriptions`. This enables support for [transcription confidence scores](https://docs.aws.amazon.com/lexv2/latest/dg/using-transcript-confidence-scores.html).

--- a/lib/aws/lex/conversation/type/transcription.rb
+++ b/lib/aws/lex/conversation/type/transcription.rb
@@ -15,7 +15,11 @@ module Aws
 
           coerce(
             resolved_context: Transcription::ResolvedContext,
-            resolved_slots: Array[Slot]
+            resolved_slots: ->(slots) do
+              slots.each_with_object({}) do |(name, data), hash|
+                hash[name.to_sym] = Slot.shrink_wrap(data)
+              end
+            end
           )
         end
       end

--- a/lib/aws/lex/conversation/version.rb
+++ b/lib/aws/lex/conversation/version.rb
@@ -3,7 +3,7 @@
 module Aws
   module Lex
     class Conversation
-      VERSION = '6.4.0'
+      VERSION = '6.4.1'
     end
   end
 end

--- a/spec/fixtures/events/intents/basic.json
+++ b/spec/fixtures/events/intents/basic.json
@@ -157,6 +157,26 @@
     },
     "originatingRequestId": "d6349818-c9a1-463e-b8e6-7fcdc5169b71"
   },
+  "transcriptions": [
+    {
+      "transcription": "yes",
+      "transcriptionConfidence": 1,
+      "resolvedContext": {
+        "intent": "Lex_V2_Intent_A"
+      },
+      "resolvedSlots": {
+        "HasACat": {
+          "shape": "Scalar",
+          "value": {
+            "originalValue": "yes",
+            "resolvedValues": [
+              "YES"
+            ]
+          }
+        }
+      }
+    }
+  ],
   "inputMode": "Text",
   "bot": {
     "aliasName": "TestBotAlias",


### PR DESCRIPTION
* With the recent update to include support for transcription
  confidence, we incorrectly specified the coercion for
  `resolvedSlots`. We receive an object/hash and were trying
  to coerce it as an array.
* To fix this, update the coercion to loop through the hash keys
  and build a correct structure for `resolved_slots`.