### PR TITLE
fix(resolved_contexts): Fix ResolvedContext#intent

### DIFF
--- a/lib/aws/lex/conversation/type/event.rb
+++ b/lib/aws/lex/conversation/type/event.rb
@@ -26,7 +26,7 @@ module Aws
             end
           end
 
-          computed_property(:intents, virutal: true) do |instance|
+          computed_property(:intents, virtual: true) do |instance|
             instance.interpretations.map(&:intent).tap do |intents|
               intents.map do |intent|
                 intent.nlu_confidence = instance.interpretations.find { |i| i.intent.name == intent.name }&.nlu_confidence

--- a/lib/aws/lex/conversation/type/transcription/resolved_context.rb
+++ b/lib/aws/lex/conversation/type/transcription/resolved_context.rb
@@ -8,7 +8,7 @@ module Aws
           class ResolvedContext
             include Base
 
-            required :intent
+            optional :intent
           end
         end
       end

--- a/lib/aws/lex/conversation/version.rb
+++ b/lib/aws/lex/conversation/version.rb
@@ -3,7 +3,7 @@
 module Aws
   module Lex
     class Conversation
-      VERSION = '6.4.1'
+      VERSION = '6.4.2'
     end
   end
 end

--- a/spec/fixtures/events/intents/basic.json
+++ b/spec/fixtures/events/intents/basic.json
@@ -175,6 +175,11 @@
           }
         }
       }
+    },
+    {
+      "transcription": "I don't know",
+      "transcriptionConfidence": 0,
+      "resolvedContext": {}
     }
   ],
   "inputMode": "Text",


### PR DESCRIPTION
* As of appx. Apr 22, ResolvedContext may not be returned, and therefore
  should not require an *intent*
* Typo fix for virtual attribute
* Style/OpenStructUse is not valid in current versions of rubocop